### PR TITLE
Add yellow-bellied toad species

### DIFF
--- a/src/pages/platforms/platformData.js
+++ b/src/pages/platforms/platformData.js
@@ -647,6 +647,11 @@ const projectData = [
         alias: 'Fire salamander',
         url: 'https://en.wikipedia.org/wiki/Fire_salamander',
       },
+      {
+        name: 'Bombina variegata',
+        alias: 'Yellow-bellied toad',
+        url: 'https://en.wikipedia.org/wiki/Yellow-bellied_toad',
+      },
     ],
   },
   {


### PR DESCRIPTION
Adds the yellow-bellied toad to the Amphibians and Reptiles platform's species section:
![species](https://user-images.githubusercontent.com/50299119/156465267-476112c5-ebd8-46f3-b259-03561783174c.jpeg)